### PR TITLE
Add nix shell to get testchain deploy environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,10 @@
-{ testchain-dss-deployment-src ? fetchGit {
+{ tdds-src ? fetchGit {
     url = https://github.com/makerdao/testchain-dss-deployment-scripts.git;
     ref = "master";
   }
 }: let
-  testchain-dss-deployment-shell = import "${testchain-dss-deployment-src}/shell.nix" {};
+  tdds-shell = import "${tdds-src}/shell.nix" {};
 in
-  testchain-dss-deployment-shell.overrideAttrs (attrs: {
-    src = testchain-dss-deployment-src;
+  tdds-shell.overrideAttrs (attrs: {
+    src = tdds-src;
   })

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+{ testchain-dss-deployment-src ? fetchGit {
+    url = https://github.com/makerdao/testchain-dss-deployment-scripts.git;
+    ref = "master";
+  }
+}: let
+  testchain-dss-deployment-shell = import "${testchain-dss-deployment-src}/shell.nix" {};
+in
+  testchain-dss-deployment-shell.overrideAttrs (attrs: {
+    src = testchain-dss-deployment-src;
+  })


### PR DESCRIPTION
By running `nix-shell` you will get the exact same dev environment as in `testchain-dss-deployment-scripts` (`tdds`) without cluttering your regular user environment. No clashing versions with binaries in your regular env.

You can also find `tdds` deploy scripts if you run `ls -al $src` inside the shell. You will not be able to run the scripts directly because they require you to be in the same directory, but with some tweaking they could be made to be run from anywhere. 

Another pro is that the dependency on `tdds` is parameterized so that injecting a different version of it can be done by calling `nix-shell` with an argument. Let's say you need to modify something in the `tdds` repo, you can then clone it and make the changes then go back to this repo and run `nix-shell --arg testchain-dss-deployment-src ../testchain-dss-deployment-scripts` (pointing to the path where you cloned `tdds`). You can also parameterize which branch or commit to check out.